### PR TITLE
fix: Add configration for connection timeout

### DIFF
--- a/qcs-api-client-grpc/src/channel.rs
+++ b/qcs-api-client-grpc/src/channel.rs
@@ -102,7 +102,11 @@ pub fn get_endpoint(uri: Uri) -> Endpoint {
 }
 
 /// Get an [`Endpoint`] for the given [`Uri`] and timeout.
-pub fn get_endpoint_with_timeout(uri: Uri, timeout: Option<Duration>, connection_timeout: Option<Duration>) -> Endpoint {
+pub fn get_endpoint_with_timeout(
+    uri: Uri,
+    timeout: Option<Duration>,
+    connection_timeout: Option<Duration>,
+) -> Endpoint {
     if let Some(duration) = timeout {
         get_endpoint(uri)
             .timeout(duration)


### PR DESCRIPTION
Currently, the clients support request timeout but not connection timeout. Connection timeout helps when controlling connection attempts to a host that might be unresponsive, or through an unknown network state.

Happy to hear your thoughts, and comments on this change.

API change: https://github.com/rigetti/qcs-sdk-rust/pull/419