### PR TITLE
fix: Increase `timeout` and `keep_alive_interval` to handle large circuits

### DIFF
--- a/qcs-api-client-common/src/backoff.rs
+++ b/qcs-api-client-common/src/backoff.rs
@@ -12,17 +12,14 @@ pub use ::backoff::*;
 
 /// Create a default [`ExponentialBackoff`] for use with QCS.
 ///
-/// This backoff will retry for up to 5 minutes. The initial interval is 30 seconds,
-/// and the backoff will double the interval each time it is used, up to the maximum
-/// interval of 2 minutes.
+/// This backoff will retry for up to 5 minutes, with a maximum interval of 30 seconds and some
+/// randomized jitter.
 #[allow(clippy::module_name_repetitions)]
 #[must_use]
 pub fn default_backoff() -> ExponentialBackoff {
     ExponentialBackoffBuilder::new()
         .with_max_elapsed_time(Some(Duration::from_secs(300)))
-        .with_initial_interval(Duration::from_secs(30))
-        .with_max_interval(Duration::from_secs(120))
-        .with_multiplier(2.0)
+        .with_max_interval(Duration::from_secs(30))
         .build()
 }
 

--- a/qcs-api-client-grpc/src/tonic/channel.rs
+++ b/qcs-api-client-grpc/src/tonic/channel.rs
@@ -341,8 +341,8 @@ pub fn parse_uri(s: &str) -> Result<Uri, Error<TokenError>> {
 }
 
 /// Get an [`Endpoint`] for the given [`Uri`] with default settings.
-/// This endpoint will default to using a 2 minute timeout, and will
-/// keep the connection alive while idle, with a 60 second keep-alive 
+/// This endpoint will default to using a 5 minute timeout, and will
+/// keep the connection alive while idle, with a 120 second keep-alive
 /// interval.
 #[allow(clippy::missing_panics_doc)]
 pub fn get_endpoint(uri: Uri) -> Endpoint {
@@ -355,8 +355,8 @@ pub fn get_endpoint(uri: Uri) -> Endpoint {
         .tls_config(ClientTlsConfig::new().with_enabled_roots())
         .expect("tls setup should succeed")
         .keep_alive_while_idle(true)
-        .http2_keep_alive_interval(Duration::from_secs(60))
-        .timeout(Duration::from_secs(120))
+        .http2_keep_alive_interval(Duration::from_secs(120))
+        .timeout(Duration::from_secs(300))
 }
 
 /// Get an [`Endpoint`] for the given [`Uri`] and custom timeout duration.


### PR DESCRIPTION
Large circuits submitted through the Q-CTRL integration can take a while (upwards of 50-60 seconds). This appears to cause the translation service - which connects to our Rigetti pre-processing endpoint - to fail with the following 'unavailable` message:

```
Call failed during gRPC request: status: Unavailable, message: "unavailable", details: [], metadata: MetadataMap { headers: {"server": "awselb/2.0", "date": "Thu, 03 Jul 2025 01:08:53 GMT", "content-type": "application/grpc", "content-length": "0"} }
```

This PR proposes a quick solution to increase the `Endpoint` timeout for `translate` to 2 minutes, as well as enable `keep_alive_while_idle` and increase the `keep_alive_interval`.